### PR TITLE
fix(dah-no-dropped-impact): :bug: suppress issue

### DIFF
--- a/validator/rules/dah-no-dropped-impact.ts
+++ b/validator/rules/dah-no-dropped-impact.ts
@@ -21,7 +21,10 @@ export default rule("dah-no-dropped-impact", function () {
   );
 
   for (const entryId of hasDroppedImpactEntries) {
-    if (!hasDroppedStatusEntries.has(entryId)) {
+    if (
+      !hasDroppedStatusEntries.has(entryId) &&
+      this.isNotIgnored(this.getEntry(entryId)!)
+    ) {
       this.warn(
         `entry '${entryId}' has a dropped impact but its status is not 'Dropped'`
       );


### PR DESCRIPTION
when one tries suppress an entry using the extension `DAH_validator_suppress`, the validator will exclude the entry from the `this.entry` iterable. however, its existence can still be seen in impact/relation contributor maps.

this effectively rendered the suppressing of such entry useless because of how the check algorithm have been doing, we need an additional check before actually warning.